### PR TITLE
README markdown formatting cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,26 @@
-# NC State Book module for Moodle (http://moodle.org/) 
+# NC State Book module for Moodle (http://moodle.org/)
 
-## Copyright (C) 2012-2017
+Copyright &copy; 2012-2017
 
-### The Book module makes it easy to create multi-page resources with a book-like format. This module can be used to build complete book-like websites inside of your Moodle course.
-### This module was developed for Technical University of Liberec (Czech Republic). Many ideas and code were taken from other Moodle modules and Moodle itself
+The Book module makes it easy to create multi-page resources with a book-like format. This module can be used to build complete book-like websites inside of your Moodle course. This module was developed for Technical University of Liberec (Czech Republic). Many ideas and code were taken from other Moodle modules and Moodle itself.
 
-#### This program is free software; you can redistribute it and/or modify
-#### it under the terms of the GNU General Public License as published by
-#### the Free Software Foundation; either version 3 of the License, or
-#### (at your option) any later version.
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
 
-##### This program is distributed in the hope that it will be useful,
-##### but WITHOUT ANY WARRANTY; without even the implied warranty of
-##### MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-##### [GNU General Public License](http://www.gnu.org/copyleft/gpl.html) for more details.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the [GNU General Public License](http://www.gnu.org/copyleft/gpl.html) for more details.
 
-# Originally Created by:
+## Originally Created by:
 
 * Petr Skoda (skodak) - Original creator of the Moodle Core Book Module
 
-# Created by:
+## Created by:
 
-* Gary Harris 
+* Gary Harris
 
-## Contributors: 
+## Contributors:
 
 * Amanda Robertson
-* Cathi Phillips Dunnagan 
-* Jeff Webster 
+* Cathi Phillips Dunnagan
+* Jeff Webster
 * David Lanier
 
 ## Intentionally omitted features:


### PR DESCRIPTION
README.md – Cleaned up markdown header formatting; switched copyright symbol to HTML entity.